### PR TITLE
Fixed bug in model when evaluating if no detection was found

### DIFF
--- a/model.py
+++ b/model.py
@@ -268,7 +268,7 @@ class ResNet(nn.Module):
 
             if scores_over_thresh.sum() == 0:
                 # no boxes to NMS, just return
-                return [torch.zeros(0), torch.zeros(0), torch.zeros(0, 4)]
+                return [torch.zeros(1), torch.zeros(1), torch.zeros(1, 4)]
 
             classification = classification[:, scores_over_thresh, :]
             transformed_anchors = transformed_anchors[:, scores_over_thresh, :]


### PR DESCRIPTION
Hi yhenon,

First of all, thanks for your work here, it's amazing. Now, I think I may have found an error when evaluating the accuracy of the network. Please correct me if I'm wrong, but I think line 271 of model.py: https://github.com/yhenon/pytorch-retinanet/blob/71f8e0a8215ebc4c54d9ad2762d47b4ec6738d32/model.py#L271 

should read:

`return [torch.zeros(1), torch.zeros(1), torch.zeros(1, 4)]`

Otherwise, DataParallel will give an error when asserting that all variables are CUDA after gathering them if no scores_over_thresh > 0 is found.
