### PR TITLE
Update classification head of the network

### DIFF
--- a/model.py
+++ b/model.py
@@ -147,16 +147,13 @@ class ClassificationModel(nn.Module):
         out = self.act4(out)
 
         out = self.output(out)
-        out = self.output_act(out)
-
+        batch_size, channels, width, height = out.shape
+        
         # out is B x C x W x H, with C = n_classes + n_anchors
-        out1 = out.permute(0, 2, 3, 1)
-
-        batch_size, width, height, channels = out1.shape
-
-        out2 = out1.view(batch_size, width, height, self.num_anchors, self.num_classes)
-
-        return out2.contiguous().view(x.shape[0], -1, self.num_classes)
+        out = out.permute(0, 2, 3, 1).contiguous().view(batch_size,-1,self.num_classes)
+        # using the last activate func after the output is reshaped as (Batch size, H*W*n_anchors, n_classes)
+        out = self.output_act(out)
+        return out
 
 class ResNet(nn.Module):
 


### PR DESCRIPTION
When I using the original loss of this repositories the focal loss of classification sticked to 2.301 and it didn't change over hundreds of iterations. After I read a few of other repositories of RetinaNet I believe that using the Sigmoid function(or Softmax function on the -1 dim) after reshaping class prediction to (Batch_size, -1, num_classes) is a more sensible way. And my classification loss finally went down.