### PR TITLE
Update visualize_single_image.py

### DIFF
--- a/visualize_single_image.py
+++ b/visualize_single_image.py
@@ -52,6 +52,9 @@ def detect_image(image_path, model_path, class_list):
     for img_name in os.listdir(image_path):
 
         image = cv2.imread(os.path.join(image_path, img_name))
+        
+        # Opencv reads images as BGR format by default. This needs to be changed to RGB, since training uses RGB, not BGR images. 
+        image = cv2.cvtColor(image,cv2.COLOR_BGR2RGB)
         if image is None:
             continue
         image_orig = image.copy()
@@ -114,8 +117,9 @@ def detect_image(image_path, model_path, class_list):
                 # draw_caption(img, (x1, y1, x2, y2), label_name)
                 draw_caption(image_orig, (x1, y1, x2, y2), caption)
                 cv2.rectangle(image_orig, (x1, y1), (x2, y2), color=(0, 0, 255), thickness=2)
-
-            cv2.imshow('detections', image_orig)
+                
+            # change from RGB-> BGR for visualization
+            cv2.imshow('detections', cv2.cvtColor(image_orig, cv2.COLOR_RGB2BGR))
             cv2.waitKey(0)
 
 


### PR DESCRIPTION
The code uses BGR images (opencv reads images as BGR by default). Since training uses RGB images, inference should use RGB images as well.